### PR TITLE
Ktmeaton patch array

### DIFF
--- a/nj.cc
+++ b/nj.cc
@@ -27,6 +27,7 @@
 #include <vector>
 #include "mars.h"
 #include "nj.h"
+#include <array>
 
 using namespace seqan;
 using namespace std;

--- a/progAlignment.cc
+++ b/progAlignment.cc
@@ -28,6 +28,7 @@
 #include "mars.h"
 #include "sacsc.h"
 #include "nj.h"
+#include <array>
 
 
 using namespace std;


### PR DESCRIPTION
Resolving compilation error (gcc 4.7.4):
"error: aggregate ‘std::array<int, 2ul> children’ has incomplete type and cannot be defined"

Added #include<array> to 2 files: nj.cc and progAlignment.cc

Compilation is now successful.
